### PR TITLE
Compatability with ESMValTool

### DIFF
--- a/geoval/core/data.py
+++ b/geoval/core/data.py
@@ -1920,12 +1920,16 @@ class GeoData(object):
         if self.data.ndim == 3:
             res = self.data.mean(axis=0)
         elif self.data.ndim == 2:
-            res = self.data.copy()  # no temporal averaging
+            if isinstance(self.data, GeoData):
+                print("FIND INSTANCE OF GEODATA IN THE DATA ARGUMENT, PLEASE FIX IT!")
+                res = self.data.data.copy()
+            else:
+                res = self.data.copy()  # no temporal averaging
         else:
             print(self.data.ndim)
             raise ValueError(
                 'Temporal mean can not be calculated as dimensions do not match!')
-
+        print(type(res))
         if return_object:
             tmp = self.copy()
             tmp.data = res

--- a/geoval/core/data.py
+++ b/geoval/core/data.py
@@ -1926,7 +1926,6 @@ class GeoData(object):
             else:
                 res = self.data.copy()  # no temporal averaging
         else:
-            print(self.data.ndim)
             raise ValueError(
                 'Temporal mean can not be calculated as dimensions do not match!')
         print(type(res))

--- a/geoval/core/mapping.py
+++ b/geoval/core/mapping.py
@@ -223,7 +223,7 @@ class MapPlotGeneric(object):
                 'No projection properties are given! Please modify or choose a different backend!')
 
         the_map = Basemap(ax=self.pax, **proj_prop)
-        xm = self.x.timmean()
+        xm = self.x.timmean(return_object=False)
 
         Z = xm
         lon = self.x.lon
@@ -310,8 +310,10 @@ class MapPlotGeneric(object):
             plot_data_field = False
 
         if plot_data_field:
-            xm = self.x.timmean()
+            xm = self.x.timmean(return_object=False)
             Z = xm
+            print(Z)
+            print(Z.shape)
             lon = self.x.lon
             lat = self.x.lat
 
@@ -382,12 +384,13 @@ class MapPlotGeneric(object):
         else:
             self.pax.set_global()  # ensure global plot
         self.pax.coastlines()
-
+        import traceback
         if plot_data_field:
             try:
                 self.im = self.pax.pcolormesh(
                     lon, lat, Z, transform=ccrs.PlateCarree(), **kwargs)
             except:
+                print(traceback.format_exc())
                 print('*** WARNING: something did not work with pcolormesh plotting in mapping.py')
                 self.im = None
         else:

--- a/geoval/core/mapping.py
+++ b/geoval/core/mapping.py
@@ -312,8 +312,6 @@ class MapPlotGeneric(object):
         if plot_data_field:
             xm = self.x.timmean(return_object=False)
             Z = xm
-            print(Z)
-            print(Z.shape)
             lon = self.x.lon
             lat = self.x.lat
 


### PR DESCRIPTION
This PR adds missing `return_object=False` in plotting functions and process the case, when `timmean` get instance of GeoData with another instance of GeoData in the attribute. There is a warning written in large, friendly letters.